### PR TITLE
fix: input content and placeholder conflict

### DIFF
--- a/frontend/src/components/login/login.js
+++ b/frontend/src/components/login/login.js
@@ -43,9 +43,10 @@ export default function Login() {
               required
               className="login_input"
               ref={input_email}
+              placeholder="Email Address"
             />
             <label for="email" className="login_input_label">
-              Email Address
+              {/* Email Address */}
             </label>
           </div>
 
@@ -56,9 +57,10 @@ export default function Login() {
               required
               className="login_input"
               ref={input_password}
+              placeholder="Password"
             />
             <label for="password" className="login_input_label">
-              Password
+              {/* Password */}
             </label>
           </div>
 


### PR DESCRIPTION
Great web app with abundant functions, and I love the visual effects when selecting different toppings for pizza!

I made some tiny changes to avoid the following situation :

<img width="373" alt="SS-2022-11-30 at 18 15 32@2x" src="https://user-images.githubusercontent.com/34364810/204950179-59b1d6fc-b03d-4faf-a9be-fd9c453e70fa.png">

Use "placeholder" property of input tag.